### PR TITLE
icalendar2対応, alartの出力フォーマット調整, watchしているチケットをicalに含める他の取り込みをお願いします。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem "icalendar"

--- a/README.rdoc
+++ b/README.rdoc
@@ -6,11 +6,11 @@
  RAILS_ENV=production rake db:migrate_plugins
 
 == How to Use
-redmineの右上にiCal設定と出てくるので
-そこをクリックして初期設定を行なってください
+1. redmineの右上の「iCal設定」をクリック
+2. 「設定」を必要に応じて変更
+3. 「access keyを更新」をクリック
 
-アクセスキー付きURLが発行されます
-
+アクセスキー付きURLが「現在の設定」の下のテキストボックスに発行されます
 http://your.domain/exports/ical/XXXXXXXXXXXXX
 
 もしベーシック認証などをかけてる場合は
@@ -19,4 +19,5 @@ http://username:password@your.domain/exports/ical/XXXXXXXXXXXXX
 
 == TODO
 - 国際化
-- watcherに入れてるissueも閲覧できるようにする？
+- watcherに入れているissueを含むかを選択できるようにする
+- [Complete] watcherに入れてるissueも閲覧できるようにする。

--- a/README.rdoc
+++ b/README.rdoc
@@ -10,14 +10,13 @@
 2. 「設定」を必要に応じて変更
 3. 「access keyを更新」をクリック
 
-アクセスキー付きURLが「現在の設定」の下のテキストボックスに発行されます
-http://your.domain/exports/ical/XXXXXXXXXXXXX
+アクセスキー付きURLが「現在の設定」の下のテキストボックスに発行されます。
+ http://your.domain/exports/ical/XXXXXXXXXXXXX
 
-もしベーシック認証などをかけてる場合は
-http://username:password@your.domain/exports/ical/XXXXXXXXXXXXX
-でアクセス可能です
+もしベーシック認証などをかけてる場合は下記のようにユーザー名、パスワードを記載するとアクセス可能になります。
+ http://username:password@your.domain/exports/ical/XXXXXXXXXXXXX
 
 == TODO
 - 国際化
 - watcherに入れているissueを含むかを選択できるようにする
-- [Complete] watcherに入れてるissueも閲覧できるようにする。
+- [Complete] watcherに入れてるissueも閲覧できるようにする

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -22,26 +22,13 @@ class ExportsController < ApplicationController
     "#{id.to_s.crypt(salt)}@example.com"
   end
 
-  def get_unclosed_my_issues(user)
-    #Today = Date.today
-    #startdt = today - ical_setting.past
-    #enddt = today + ical_setting.future
-
-    #watchers = []
-    #watch_users = []
-    #Watcher.find(:all,
-    #  :joins => "LEFT JOIN users ON watchers.user_id = users.id", :conditions => ["watchers.user_id = ? AND watchers.watchable_type = ?", user.id, "Issue"]).each do  |watcher|
-    #  watchers << watcher.watchable_id
-    #  watch_users << watcher.user
-    #end
-    #issues = Issue.find(:all, :conditions => ["start_date >= ? AND due_date <= ? AND (assigned_to_id = ? OR id IN (?) )", startdt, enddt, user.id, watchers.uniq])
-
+  def get_unclosed_my_issues(user_id)
     # 未完了で自分の担当のチケットを取得
     #issues = Issue.find(:all, :joins => "LEFT JOIN issue_statuses AS st ON issues.status_id = st.id", :conditions => ["issues.start_date <= ? AND issues.due_date <= ? AND issues.assigned_to_id = ? AND st.is_closed = ?", startdt, enddt, user.id, false])
-    issues = Issue.find(:all, :joins => "LEFT JOIN issue_statuses AS st ON issues.status_id = st.id", :conditions => ["issues.assigned_to_id = ? AND st.is_closed = ?", user.id, false])
+    issues = Issue.find(:all, :joins => "LEFT JOIN issue_statuses AS st ON issues.status_id = st.id", :conditions => [" issues.assigned_to_id = ? AND st.is_closed = ? AND NOT start_date = ""?"" AND NOT due_date = ""?"" ", user_id , false, "", ""])
 
     # Add watching issues, too
-    #issues += Issue.find(:all, :joins => "LEFT JOIN issue_statuses AS st ON issues.status_id = st.id", :conditions => ["? IN (issues.watcher_user_ids) AND st.is_closed = ?", user.id,  false])
+    issues |= Issue.find(:all, :joins => "LEFT JOIN watchers ON NOT issues.status_id = 5 AND issues.id =  watchers.watchable_id" , :conditions => [ "watchers.watchable_type = ""?""" , "Issue" ]  )
     return issues
   end
 
@@ -128,7 +115,7 @@ class ExportsController < ApplicationController
     cal.prodid = "Redmine iCal Plugin"
 
     # Add events from issue
-    issues = get_unclosed_my_issues(user)
+    issues = get_unclosed_my_issues(user.id)
     issues.each do |issue|
       next if issue.start_date.blank?
       next if issue.due_date.blank?

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -114,7 +114,7 @@ class ExportsController < ApplicationController
       watcher_join = "LEFT JOIN users ON watchers.user_id = users.id"
       watcher_condition =  ["watchers.watchable_type = ? AND watchers.watchable_id = ?", "Issue", issue.id]
       Watcher.find(:all,:joins => watcher_join ,:conditions => watcher_condition ).each do |watcher|
-        watched_.user = watcher.user
+        watched_user = watcher.user
         attendee = Attendee.new(watched_user.mail, {"CN" => watched_user.name})
         event.append_custom_property attendee.property_name, attendee.value
       end

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -111,6 +111,8 @@ class ExportsController < ApplicationController
 
       event.append_custom_property("ORGANIZER;CN=#{user.name}", "MAILTO:#{user.mail}")
       event.append_custom_property("ATTENDEE;ROLE=CHAIR;CN=#{user.name}", "MAILTO:#{user.mail}")
+
+      # Set watcher as attendee
       watcher_join = "LEFT JOIN users ON watchers.user_id = users.id"
       watcher_condition =  ["watchers.watchable_type = ? AND watchers.watchable_id = ?", "Issue", issue.id]
       Watcher.find(:all,:joins => watcher_join ,:conditions => watcher_condition ).each do |watcher|
@@ -184,8 +186,6 @@ class ExportsController < ApplicationController
       "MAILTO:#{mailto}"
     end
   end
-
-
 
 end
 


### PR DESCRIPTION
RedmineのチケットをOutlookの機能を使って見れるので便利に利用させていただいています。

使おうとしたときにいくつか使いやすくするために、修正していたのですが、もしよかったら
取り込んでいただけないでしょうか。

主な対応は下記のとおりです。
- icalendar2利用を明記＆動作するように修正
- alartの出力フォーマット調整 (AlartにNONEを指定すると、Outlookで一部エラーになるので、AlartがOFF時はAlart属性が出ないように調整)
- generate_calendarから、Issue獲得部分、イベント作成部分の切り分け (可読性向上)
- (ホワイトスペースの数などを変更。すいません、自分のエディタで見やすいようにあわせてしまっています）
